### PR TITLE
Correct a Typo that may lead to errors during user checking

### DIFF
--- a/pretrain/contrastive_scene_contexts/lib/ddp_data_loaders.py
+++ b/pretrain/contrastive_scene_contexts/lib/ddp_data_loaders.py
@@ -113,7 +113,7 @@ def default_collate_pair_fn(list_data):
       'sinput0_C': coords_batch0,
       'sinput0_F': feats_batch0,
       'sinput0_L': label_batch0,
-      'sinput0_I': instance_batch1,
+      'sinput0_I': instance_batch0,
       'sinput1_C': coords_batch1,
       'sinput1_F': feats_batch1,
       'sinput1_L': label_batch1,


### PR DESCRIPTION
This is just a simple typo error, but may lead to errors if users check the instance label during processing pretrained data.